### PR TITLE
Fix Progress for default UI

### DIFF
--- a/src/app/dashboard/_components/ProgressSection.tsx
+++ b/src/app/dashboard/_components/ProgressSection.tsx
@@ -48,12 +48,14 @@ const Component = ({ userId, date }: ProgressSectionProps) => {
   //For progressCircle UI
   const progressValue =
     totalKcal && targetKcal ? Math.floor((totalKcal / targetKcal) * 100) : 0;
-  const totalKcalDisplay = totalKcal ? totalKcal : null;
-  const targetKcalDisplay = targetKcal ? targetKcal : null;
+  const totalKcalDisplay = totalKcal === undefined ? null : totalKcal;
+  const targetKcalDisplay = targetKcal === undefined ? null : targetKcal;
 
   //For prgoress remainingKcal UI
   const remainingKcalValue =
-    totalKcal && targetKcal ? Math.floor(targetKcal! - totalKcal!) : null;
+    targetKcal != null && totalKcal != null
+      ? Math.floor(targetKcal - totalKcal)
+      : null;
 
   return (
     <>


### PR DESCRIPTION
## #55 Progressの初期時のUIを修正

### 概要
ユーザーがまだ食事履歴を登録していない時（totalkcalが0）にnullが返り、下記場所に何も表示されていない問題を修正しました。
- 円の上の数字（ユーザーの現在の摂取カロリー合計値）→ **初期値を０にしたい**
- 残りカロリーの数字（ユーザーの目標カロリー(2800)から上記合計値を引いた数字）→ **上記合計値が０の時も表示させたい**

### UI
#### 修正前
<img width="300" height="auto" alt="データ0時のProgress" src="https://github.com/user-attachments/assets/1142b62d-f0ba-465f-a5df-3fac8dbb485f" /><br>

#### 修正後
<img width="300" height="auto" alt="Fix-データ0時のProgress" src="https://github.com/user-attachments/assets/fe4359e7-2630-4c22-81ed-26510210eab0" />
