### PR TITLE
Changed table name from targetKcalHistory to targetKcalPlans

### DIFF
--- a/src/app/dashboard/_components/ProgressSection.tsx
+++ b/src/app/dashboard/_components/ProgressSection.tsx
@@ -34,7 +34,7 @@ const Component = ({ userId, date }: ProgressSectionProps) => {
     isLoading: targetKcalIsLoading,
     isError: targetKcalIsError,
   } = useQuery({
-    queryKey: TargetKcalkeys.list(userId),
+    queryKey: TargetKcalkeys.effective(userId),
     queryFn: () => getEfeectiveTargetKcal(userId, date),
     meta: { errCode: TErrCodes.PROGRESS_FETCH_FAILED },
   });

--- a/src/utils/api/history.ts
+++ b/src/utils/api/history.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { db } from "@/db";
-import { mealRecords, targetKcalHistory } from "@/db/schema";
+import { mealRecords, targetKcalPlans } from "@/db/schema";
 import { sql, desc, and, eq, lte } from "drizzle-orm";
 
 type getDailyKcalSummaryProps = {
@@ -34,17 +34,17 @@ export async function getDailyKcalSummary({
 
   const targetKcalData = await db
     .select({
-      date: targetKcalHistory.effectiveDate,
-      targetKcal: targetKcalHistory.targetKcal,
+      date: targetKcalPlans.effectiveDate,
+      targetKcal: targetKcalPlans.targetKcal,
     })
-    .from(targetKcalHistory)
+    .from(targetKcalPlans)
     .where(
       and(
-        eq(targetKcalHistory.userId, userId),
-        lte(targetKcalHistory.effectiveDate, dates[0])
+        eq(targetKcalPlans.userId, userId),
+        lte(targetKcalPlans.effectiveDate, dates[0])
       )
     )
-    .orderBy(desc(targetKcalHistory.effectiveDate));
+    .orderBy(desc(targetKcalPlans.effectiveDate));
 
   //各日付の合計データに対応する有効な目標カロリーを紐づけて返す
   const result = totalKcalData.map((dailyRecord) => {

--- a/src/utils/api/setup.ts
+++ b/src/utils/api/setup.ts
@@ -3,9 +3,9 @@
 import { db } from "@/db";
 import {
   InsertProfileRecord,
-  InsertTargetKcalHistoryRecord,
+  InsertTargetKcalPlansRecord,
   profiles,
-  targetKcalHistory,
+  targetKcalPlans,
 } from "@/db/schema";
 
 //Setup user Name
@@ -22,8 +22,8 @@ export async function createTargetKcal({
   userId,
   targetKcal,
   effectiveDate,
-}: InsertTargetKcalHistoryRecord) {
-  return await db.insert(targetKcalHistory).values({
+}: InsertTargetKcalPlansRecord) {
+  return await db.insert(targetKcalPlans).values({
     id: id,
     userId: userId,
     targetKcal: targetKcal,


### PR DESCRIPTION
## 1日の目標カロリーのテーブル名を変更

### 概要
ユーザーが登録・編集・削除ができる 1日の目標カロリーページを、以前は「履歴」という意味を込めてテーブル名をtargetKaclHistoryにしていました。しかし、使用するメインの目的は、段階的に未来の目標カロリーを設定できることです。
そのためテーブル名をtargetKacPlansに変更しました。