### PR TITLE
Add Timezone for getting History page

### DIFF
--- a/src/utils/api/history.ts
+++ b/src/utils/api/history.ts
@@ -30,7 +30,9 @@ export async function fetchDailyKcalSummary({
   //Sum the calories for each day over the 7-day period
   const totalKcalData = await db
     .select({
-      date: sql<string>`DATE(${mealRecords.eatenAt})`.as("date"),
+      date: sql<string>`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo')`.as(
+        "date"
+      ),
       totalKcal: sql<number>`SUM(${mealRecords.kcal})`.as("total_kcal"),
     })
     .from(mealRecords)
@@ -39,13 +41,13 @@ export async function fetchDailyKcalSummary({
         ${mealRecords.userId} = ${userId}
         ${
           currentCursor
-            ? sql`AND DATE(${mealRecords.eatenAt}) < ${currentCursor}`
+            ? sql`AND DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo') < ${currentCursor}`
             : sql``
         }
       `
     )
-    .groupBy(sql`DATE(${mealRecords.eatenAt})`)
-    .orderBy(desc(sql`DATE(${mealRecords.eatenAt})`))
+    .groupBy(sql`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo')`)
+    .orderBy(desc(sql`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo')`))
     .limit(limit);
 
   if (totalKcalData.length === 0) return { items: [], nextCursor: null };


### PR DESCRIPTION
## Historyページの日付のずれを修正

### 概要
Historyページではユーザーの1日のトータルKcalを取得してリスト表示をしていました。
しかし、データを取得するクエリにtimezondでフィルターをかけていなかったため、日付にずれが生じていました。
例：2025-1202 01:00に登録 → UTCで取得していたため日付が変わり、2025-1201 16:00にフィルタリングされていた。

クエリに`AT TIME ZONE 'Asia/Tokyo'`を追加してUTC→JSTでフィルターをかけて取得するように修正しました。
