### PR TITLE
Refactor/function renames and imports

### DIFF
--- a/src/app/_component/CtaSection.tsx
+++ b/src/app/_component/CtaSection.tsx
@@ -1,12 +1,11 @@
 import { GetStartedButton } from "@/components";
 import { CardHeader, CardWithShadow } from "@/components/ui";
+import { checkAuthClient } from "@/utils/auth";
 import Image from "next/image";
 
-type CtaSectionProps = {
-  isLoggedIn: boolean;
-};
+export const CtaSection = async () => {
+  const isLoggedIn = await checkAuthClient();
 
-export const CtaSection = ({ isLoggedIn }: CtaSectionProps) => {
   return (
     <section className="min-h-[70vh] grid place-items-center p-[5%] md:min-h-screen">
       <CardWithShadow className="max-w-2xl">

--- a/src/app/_component/HiroSection.tsx
+++ b/src/app/_component/HiroSection.tsx
@@ -1,13 +1,12 @@
 import { GetStartedButton } from "@/components";
 import { Button } from "@/components/ui";
+import { checkAuthClient } from "@/utils/auth";
 import Image from "next/image";
 import Link from "next/link";
 
-type HiroSectionProps = {
-  isLoggedIn: boolean;
-};
+export const HiroSection = async () => {
+  const isLoggedIn = await checkAuthClient();
 
-export const HiroSection = ({ isLoggedIn }: HiroSectionProps) => {
   return (
     <section>
       <div className="w-full h-full p-[5%] min-h-[100vh] gap-12 flex flex-col place-items-center md:flex-row md:place-items-start md:gap-6">

--- a/src/app/dashboard/histories/[date]/page.tsx
+++ b/src/app/dashboard/histories/[date]/page.tsx
@@ -4,7 +4,7 @@ import {
 } from "@/app/dashboard/_components";
 import { PageHeader } from "@/components";
 import { fetchUserDailyMealRecords } from "@/utils/api/mealRecords";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import { formatDateWithDay } from "@/utils/format";
 import { getQueryClient, mealRecordkeys } from "@/utils/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
@@ -14,7 +14,7 @@ export default async function MealDetailPage({
 }: {
   params: Promise<{ date: string }>;
 }) {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
   const queryClient = getQueryClient();
   const { date } = await params;
 

--- a/src/app/dashboard/histories/page.tsx
+++ b/src/app/dashboard/histories/page.tsx
@@ -1,12 +1,12 @@
 import { HistoryList } from "@/app/dashboard/histories/_components";
 import { PageHeader } from "@/components";
 import { fetchDailyKcalSummary } from "@/utils/api/history";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import { getQueryClient, historieskeys } from "@/utils/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function HistoryPage() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
   const queryClient = getQueryClient();
   const limit = 7;
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,13 +4,13 @@ import {
 } from "@/app/dashboard/_components";
 import { PageHeader } from "@/components";
 import { fetchUserDailyMealRecords } from "@/utils/api/mealRecords";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import { formatDateWithDay, getToday } from "@/utils/format";
 import { getQueryClient, mealRecordkeys } from "@/utils/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function Dashboard() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
   const queryClient = getQueryClient();
 
   const today = getToday();

--- a/src/app/dashboard/regular-foods/page.tsx
+++ b/src/app/dashboard/regular-foods/page.tsx
@@ -1,12 +1,12 @@
 import { RegularFoodSection } from "@/app/dashboard/regular-foods/_components";
 import { PageHeader } from "@/components";
 import { fetchUserRegularFoods } from "@/utils/api/regularFoods";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import { getQueryClient, RegularFoodskeys } from "@/utils/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function RegularFoodsPage() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
   const queryClient = getQueryClient();
 
   await queryClient.prefetchQuery({

--- a/src/app/dashboard/target-Kcal-plans/page.tsx
+++ b/src/app/dashboard/target-Kcal-plans/page.tsx
@@ -1,12 +1,12 @@
 import { TargetKcalSection } from "@/app/dashboard/target-kcal-plans/_component";
 import { PageHeader } from "@/components";
 import { fetchUserTargetKcal } from "@/utils/api/targetKcal";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import { getQueryClient, TargetKcalkeys } from "@/utils/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export default async function TargetKcalPage() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
 
   const queryClient = getQueryClient();
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,18 +5,15 @@ import {
   HiroSection,
   HowToUseSection,
 } from "@/app/_component";
-import { checkAuthClient } from "@/utils/auth";
 
 export default async function Home() {
-  const isLoggedIn = await checkAuthClient();
-
   return (
     <>
       <Header />
       <main className="flex flex-col gap-[32px] justify-center">
-        <HiroSection isLoggedIn={isLoggedIn} />
+        <HiroSection />
         <HowToUseSection />
-        <CtaSection isLoggedIn={isLoggedIn} />
+        <CtaSection />
       </main>
       <Footer />
     </>

--- a/src/app/setup/step-1-user-profile/page.tsx
+++ b/src/app/setup/step-1-user-profile/page.tsx
@@ -1,9 +1,9 @@
 import { UserNameForm } from "@/app/setup/_components";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import React from "react";
 
 export default async function SetUserProfile() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
 
   return <UserNameForm userId={userId} />;
 }

--- a/src/app/setup/step-2-target-kcal/page.tsx
+++ b/src/app/setup/step-2-target-kcal/page.tsx
@@ -1,9 +1,9 @@
 import { TargetKcalForm } from "@/app/setup/_components";
-import { getUserIdBycheckAuth } from "@/utils/auth";
+import { getUserId } from "@/utils/auth";
 import React from "react";
 
 export default async function SetFirstTargetKcal() {
-  const userId = await getUserIdBycheckAuth();
+  const userId = await getUserId();
 
   return <TargetKcalForm userId={userId} />;
 }

--- a/src/utils/auth.ts
+++ b/src/utils/auth.ts
@@ -2,7 +2,7 @@ import { createClient } from "@/utils/supabase/server";
 import { redirect } from "next/navigation";
 
 //Check JWT auth and get userId
-export const getUserIdBycheckAuth = async () => {
+export const getUserId = async () => {
   const supabase = await createClient();
 
   const { data, error } = await supabase.auth.getClaims();


### PR DESCRIPTION
## atuh関数名の変更とログインチェック関数のインポートの修正

### 概要
冗長だったuseIdを取得する関数名を短縮しました。
変更前：getUserIdBycheckAuth
変更後：getUserId

ダッシュボードの「カロリーチを始める」ボタンのユーザーログインチェック関数を、それぞれのコンポーネントで読み込むよう修正しました。