### PR TITLE
fix dashboard today date

### DIFF
--- a/src/app/dashboard/_components/MealRecordSection.tsx
+++ b/src/app/dashboard/_components/MealRecordSection.tsx
@@ -4,14 +4,17 @@ import {
   MealRecordAddOption,
   MealRecordLists,
 } from "@/app/dashboard/_components/";
+import { formatYYMMDD } from "@/utils/format/date";
 import { memo } from "react";
 
 type MealRecordSectionProps = {
   userId: string;
-  date: string;
 };
 
-const Component = ({ userId, date }: MealRecordSectionProps) => {
+const today = new Date();
+const date = formatYYMMDD(today);
+
+const Component = ({ userId }: MealRecordSectionProps) => {
   return (
     <>
       <MealRecordLists userId={userId} date={date} />

--- a/src/app/dashboard/_components/ProgressSection.tsx
+++ b/src/app/dashboard/_components/ProgressSection.tsx
@@ -7,16 +7,19 @@ import {
 } from "@/app/dashboard/_components/";
 import { getTodayTotalKcal } from "@/utils/api/progress";
 import { getEfeectiveTargetKcal } from "@/utils/api/targetKcal";
+import { formatYYMMDD } from "@/utils/format/date";
 import { mealRecordkeys, TargetKcalkeys, TErrCodes } from "@/utils/tanstack";
 import { useQuery } from "@tanstack/react-query";
 import { memo } from "react";
 
 type ProgressSectionProps = {
   userId: string;
-  date: string;
 };
 
-const Component = ({ userId, date }: ProgressSectionProps) => {
+const today = new Date();
+const date = formatYYMMDD(today);
+
+const Component = ({ userId }: ProgressSectionProps) => {
   //Get user's diary amount Kcal form mealRecords
   const {
     data: totalKcal,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -3,18 +3,14 @@ import {
   ProgressSection,
 } from "@/app/dashboard/_components";
 import { getUserId } from "@/utils/auth";
-import { formatYYMMDD } from "@/utils/format/date";
 
 export default async function Dashboard() {
   const userId = await getUserId();
 
-  const today = new Date();
-  const date = formatYYMMDD(today);
-
   return (
     <>
-      <ProgressSection userId={userId} date={date} />
-      <MealRecordSection userId={userId} date={date} />
+      <ProgressSection userId={userId} />
+      <MealRecordSection userId={userId} />
     </>
   );
 }


### PR DESCRIPTION
## ダッシュボードの日付取得方法の変更

### 概要
RSCであるpage.tsxで日付取得をしていたため、日付がキャッシュされていて取得するデータにずれが生じていた。
日付は各RCCで取得するよう修正しました。
