### PR TITLE
 Fix get targetDate when referencing past data

### DIFF
--- a/src/app/dashboard/_components/MealRecordSection.tsx
+++ b/src/app/dashboard/_components/MealRecordSection.tsx
@@ -9,12 +9,13 @@ import { memo } from "react";
 
 type MealRecordSectionProps = {
   userId: string;
+  targetDate?: string;
 };
 
-const today = new Date();
-const date = formatYYMMDD(today);
+const Component = ({ userId, targetDate }: MealRecordSectionProps) => {
+  // Use targetDate when referencing past data or get current-day
+  const date = targetDate ? targetDate : formatYYMMDD(new Date());
 
-const Component = ({ userId }: MealRecordSectionProps) => {
   return (
     <>
       <MealRecordLists userId={userId} date={date} />

--- a/src/app/dashboard/_components/ProgressSection.tsx
+++ b/src/app/dashboard/_components/ProgressSection.tsx
@@ -14,12 +14,13 @@ import { memo } from "react";
 
 type ProgressSectionProps = {
   userId: string;
+  targetDate?: string;
 };
 
-const today = new Date();
-const date = formatYYMMDD(today);
+const Component = ({ userId, targetDate }: ProgressSectionProps) => {
+  // Use targetDate when referencing past data or get current-day
+  const date = targetDate ? targetDate : formatYYMMDD(new Date());
 
-const Component = ({ userId }: ProgressSectionProps) => {
   //Get user's diary amount Kcal form mealRecords
   const {
     data: totalKcal,

--- a/src/app/dashboard/histories/[date]/page.tsx
+++ b/src/app/dashboard/histories/[date]/page.tsx
@@ -16,11 +16,11 @@ export default async function MealDetailPage({
 }) {
   const userId = await getUserId();
   const queryClient = getQueryClient();
-  const { date } = await params;
+  const { date: targetDate } = await params;
 
   await queryClient.prefetchQuery({
-    queryKey: mealRecordkeys.dailyList(userId, date),
-    queryFn: () => fetchUserDailyMealRecords(userId, date),
+    queryKey: mealRecordkeys.dailyList(userId, targetDate),
+    queryFn: () => fetchUserDailyMealRecords(userId, targetDate),
   });
 
   const dehydratedState = dehydrate(queryClient);
@@ -28,12 +28,12 @@ export default async function MealDetailPage({
   return (
     <>
       <PageHeader
-        title={formatDateWithDay(new Date(date))}
+        title={formatDateWithDay(new Date(targetDate))}
         description="過去の食事履歴の詳細です。"
       />
       <HydrationBoundary state={dehydratedState}>
-        <ProgressSection userId={userId} date={date} />
-        <MealRecordSection userId={userId} date={date} />
+        <ProgressSection userId={userId} targetDate={targetDate} />
+        <MealRecordSection userId={userId} targetDate={targetDate} />
       </HydrationBoundary>
     </>
   );


### PR DESCRIPTION
## 日付取得ロジックを各セクションに集約し、過去データ参照時のビルドエラーを修正

### 概要
#95の変更により、日付取得の責務を`dashboard/page.tsx`から`ProgressSection`・`MealRecordSection`に移し、各セクションが受け取った日付を用いてクエリを実行する構成に変更しました。

ただし、これらのセクションは過去データ詳細ページ（history/[date].tsx）でも共通利用されているため、参照日付が渡らずビルドエラーが発生していました。

今回のPRでは各セクションに`targetDate`を明示的に渡すよう修正し、過去データ参照時は`targetDate`を使用、未指定時は`new Date()`を使用して適切な日付でデータ取得を行うように対応しています。