### PR TITLE
Fix correctly filter meal records by JST date

### DIFF
--- a/src/utils/api/mealRecords.ts
+++ b/src/utils/api/mealRecords.ts
@@ -8,8 +8,7 @@ import {
   SelectMealRecord,
   userFoodSelections,
 } from "@/db/schema";
-import { endOfDay, startOfDay } from "date-fns";
-import { and, asc, eq, gte, like, lte, sql } from "drizzle-orm";
+import { and, asc, eq, like, sql } from "drizzle-orm";
 import { v7 as uuidv7 } from "uuid";
 
 //Get user diary　mealRecords
@@ -20,8 +19,7 @@ export const fetchUserDailyMealRecords = async (
   const res = await db.query.mealRecords.findMany({
     where: and(
       eq(mealRecords.userId, userId),
-      gte(mealRecords.eatenAt, startOfDay(date)),
-      lte(mealRecords.eatenAt, endOfDay(date))
+      sql`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo') = ${date}`
     ),
     orderBy: [asc(mealRecords.eatenAt), asc(mealRecords.id)],
   });


### PR DESCRIPTION
## 今日の食事履歴リストをJST基準で正しくフィルタリングよう修正

### 概要
今日の食事リスト一覧取得がUTCで取っていたため、夜中の1:00などのデータが前日の日付にずれ込む現象を修正しました。
