### PR TITLE
Fix correctly filter progress area by JST date

### DIFF
--- a/src/utils/api/progress.ts
+++ b/src/utils/api/progress.ts
@@ -2,8 +2,7 @@
 
 import { db } from "@/db";
 import { mealRecords } from "@/db/schema";
-import { endOfDay, startOfDay } from "date-fns";
-import { and, eq, gte, lte, sum } from "drizzle-orm";
+import { and, eq, sql, sum } from "drizzle-orm";
 
 //Get user amount Kcal diary mealRecords
 export const getTodayTotalKcal = async (userId: string, date: string) => {
@@ -13,8 +12,7 @@ export const getTodayTotalKcal = async (userId: string, date: string) => {
     .where(
       and(
         eq(mealRecords.userId, userId),
-        gte(mealRecords.eatenAt, startOfDay(date)),
-        lte(mealRecords.eatenAt, endOfDay(date))
+        sql`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo') = ${date}`
       )
     );
 


### PR DESCRIPTION
## Progressセクションの参照データをJST基準で取得するよう修正

### 概要

Progressセクションの摂取カロリー合計を算出する元データの取得がUTCで取っていたため、夜中の1:00などのデータが反映されないバグを修正しました。