### PR TITLE
Fix spacing for mealRecordForm date and time input area

### DIFF
--- a/src/app/dashboard/_components/MealRecordForm.tsx
+++ b/src/app/dashboard/_components/MealRecordForm.tsx
@@ -215,19 +215,19 @@ export const MealRecordForm = ({
             className="space-y-4 px-6 w-full"
           >
             <FieldGroup>
-              <div className="flex w-full gap-4">
+              <div className="flex gap-4">
                 <Controller
                   control={form.control}
                   name="date"
                   render={({ field, fieldState }) => (
-                    <Field data-invalid={fieldState.invalid} className="flex-1">
+                    <Field data-invalid={fieldState.invalid}>
                       <FieldLabel htmlFor={field.name}>日付</FieldLabel>
                       <Input
                         {...field}
                         id={field.name}
                         aria-invalid={fieldState.invalid}
                         type="date"
-                        className="box-border"
+                        className="px-0 justify-center"
                       />
                       {fieldState.invalid && (
                         <FieldError errors={[fieldState.error]} />
@@ -240,14 +240,14 @@ export const MealRecordForm = ({
                   control={form.control}
                   name="time"
                   render={({ field, fieldState }) => (
-                    <Field data-invalid={fieldState.invalid} className="flex-1">
+                    <Field data-invalid={fieldState.invalid}>
                       <FieldLabel htmlFor={field.name}>時間</FieldLabel>
                       <Input
                         {...field}
                         id={field.name}
                         aria-invalid={fieldState.invalid}
                         type="time"
-                        className="box-border"
+                        className="px-0 justify-center"
                       />
                       {fieldState.invalid && (
                         <FieldError errors={[fieldState.error]} />

--- a/src/app/dashboard/target-kcal-plans/_component/TargetKcalPlanForm.tsx
+++ b/src/app/dashboard/target-kcal-plans/_component/TargetKcalPlanForm.tsx
@@ -193,7 +193,7 @@ export const TargetKcalPlanForm = ({
                         id={field.name}
                         aria-invalid={fieldState.invalid}
                         type="date"
-                        className={`w-40 ${
+                        className={`w-40 px-0 justify-center${
                           isDateEditable
                             ? "disabled:opacity-100 text-muted-foreground cursor-not-allowed"
                             : ""

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -9,7 +9,7 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
         type={type}
         data-slot="input"
         className={cn(
-          "relative z-10",
+          "z-10",
           "file: text-foreground placeholder:text-muted-foreground selection:bg-primary selection:text-primary-foreground dark:bg-input/30 border-foreground flex h-10 w-full min-w-0 rounded-lg border bg-card px-3 py-1 transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-card file:text-sm file:font-medium disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
           "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
           "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",


### PR DESCRIPTION
## MearRecordFormのインプットエリアのスペースを修正

### 概要
フォーム日付と時間の横並びUIが、スマートフォン時のみ下記の画像のようにずれが生じていました。
paddingを削除し、中の要素をセンター寄せにして修正を行いました。

### 修正前
<img src="https://github.com/user-attachments/assets/f2f1a3f2-ecdc-41ed-bc29-3aa5d8309624" width="250">

### 修正後
