### PR TITLE
Add Hono middleware

### DIFF
--- a/src/app/api/[[...route]]/route.ts
+++ b/src/app/api/[[...route]]/route.ts
@@ -1,11 +1,5 @@
-import { Hono } from "hono";
+import app from "@/backend";
 import { handle } from "hono/vercel";
-
-const app = new Hono().basePath("/api");
-
-app.get("/health", (c) => {
-  return c.json({ status: "OK" });
-});
 
 export const GET = handle(app);
 export const POST = handle(app);

--- a/src/backend/Middleware/auth.ts
+++ b/src/backend/Middleware/auth.ts
@@ -1,0 +1,31 @@
+// src/lib/auth-middleware.ts
+import { createClient } from "@/lib/supabase/server";
+import { createMiddleware } from "hono/factory";
+
+// 型定義
+declare module "hono" {
+  interface ContextVariableMap {
+    userId: string;
+  }
+}
+
+export const authMiddleware = createMiddleware(async (c, next) => {
+  const supabase = await createClient();
+  const token = c.req.header("Authorization")?.replace("Bearer ", "");
+
+  if (!token) {
+    return c.json({ error: "認証が必要です" }, 401);
+  }
+
+  const {
+    data: { user },
+    error,
+  } = await supabase.auth.getUser(token);
+
+  if (error || !user) {
+    return c.json({ error: "無効なトークンです" }, 401);
+  }
+
+  c.set("userId", user.id);
+  await next();
+});

--- a/src/backend/index.ts
+++ b/src/backend/index.ts
@@ -1,0 +1,26 @@
+import { authMiddleware } from "@/backend/Middleware/auth";
+import { db } from "@/db";
+import { mealRecords } from "@/db/schema";
+import { and, asc, eq, sql } from "drizzle-orm";
+import { Hono } from "hono";
+
+const app = new Hono().basePath("/api");
+
+app.use("/dashboard/*", authMiddleware);
+
+app.get("/dashboard/meal-records/:date", async (c) => {
+  const date = c.req.param("date");
+  const userId = c.get("userId");
+
+  const data = await db.query.mealRecords.findMany({
+    where: and(
+      eq(mealRecords.userId, userId),
+      sql`DATE(${mealRecords.eatenAt} AT TIME ZONE 'Asia/Tokyo') = ${date}`,
+    ),
+    orderBy: [asc(mealRecords.eatenAt), asc(mealRecords.id)],
+  });
+
+  return c.json({ mealRecords: data });
+});
+
+export default app;


### PR DESCRIPTION
# Hono.jsでAPI ルート用の認証ミドルウェア導入

#117

## 実装内容

- Next.jsのapiルートでHonoファイルをインポート
- Hono.jsでミドルウェアの作成
- SupabaseのMealRecordsテーブルからデータを取得

## 概要
全リクエストにuserIdが必要なため、apiのルート`/api/dashboard/*`以下に共通でミドルウェアを設置しました。
フロントからのリクエスト時にヘッダーに`Authorization`を追加が必要です。

## データ取得チェック
下記コードをターミナル上で実行し、データ取得ができることを確認しました。

```bash
curl \
  "http://localhost:3000/dashboard/meal-records/2026-02-08" \
  -H "Authorization: Bearer  [ここにSupabaseアクセストークンを入れる]"
```