### PR TITLE
separate signup schema to avoid refine+omit build error

### DIFF
--- a/src/app/auth/_components/_schema/signupSchema.ts
+++ b/src/app/auth/_components/_schema/signupSchema.ts
@@ -1,19 +1,21 @@
 import { z } from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
 
-const signupSchema = z
-  .object({
-    email: z.email({ message: "有効なメールアドレスを入力してください" }),
-    password: z.string().min(6, { message: "6文字以上で入力してください" }),
-    confirmPassword: z.string(),
-  })
-  .refine((data) => data.password === data.confirmPassword, {
+const signupBaseSchema = z.object({
+  email: z.email({ message: "有効なメールアドレスを入力してください" }),
+  password: z.string().min(6, { message: "6文字以上で入力してください" }),
+  confirmPassword: z.string(),
+});
+
+export const signupSchema = signupBaseSchema.refine(
+  (data) => data.password === data.confirmPassword,
+  {
     message: "パスワードが一致しません",
     path: ["confirmPassword"],
-  });
+  },
+);
 
-//for api
-export const signupSchemaOutput = signupSchema.omit({
+export const signupSchemaOutput = signupBaseSchema.omit({
   confirmPassword: true,
 });
 


### PR DESCRIPTION
## Signupフォームのバリデーションエラー修正

### 概要

Signupフォームのバリデーションスキーマで、refineを含むschemaに.omit()を使ったことが原因でビルドエラーが発生していました。

### 修正内容
一つだったスキーマを、signupBaseSchema（純粋な object schema）とsignupSchema（フォーム用で refine 付き）を別々の変数に分けることで解決しました。