### PR TITLE
Add URL for preview environment

### DIFF
--- a/src/lib/getBaseUrl.ts
+++ b/src/lib/getBaseUrl.ts
@@ -1,7 +1,12 @@
 export function getBaseUrl() {
+  if (process.env.VERCEL_ENV === "preview") {
+    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+  }
+
   if (process.env.NODE_ENV === "production") {
     return process.env.NEXT_PUBLIC_ORIGIN!;
   }
+
   return typeof window !== "undefined"
     ? window.location.origin
     : process.env.NEXT_PUBLIC_ORIGIN!;


### PR DESCRIPTION
## ベースURLにpreview環境を追加

## 概要
各ブランチごとにVercelでプレビューを行った時に、vercelが自動で生成するpreview用のURLに対して、
apiのURLがエラーとなっていました。

vercel用のシステム環境変数の`VERCEL_ENV"`を利用して、
preview用のURLを参照するように修正しました。