### PR TITLE
Fix URL for preview Environments

### DIFF
--- a/src/lib/getBaseUrl.ts
+++ b/src/lib/getBaseUrl.ts
@@ -1,12 +1,15 @@
 export function getBaseUrl() {
-  if (process.env.VERCEL_ENV === "preview") {
-    return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
+  // Preview環境
+  if (process.env.VERCEL_URL && process.env.VERCEL_ENV === "preview") {
+    return `https://${process.env.VERCEL_URL}`;
   }
 
+  // Production本番
   if (process.env.NODE_ENV === "production") {
     return process.env.NEXT_PUBLIC_ORIGIN!;
   }
 
+  // ローカル開発
   return typeof window !== "undefined"
     ? window.location.origin
     : process.env.NEXT_PUBLIC_ORIGIN!;


### PR DESCRIPTION
## Hono baseURLの修正

## 概要
HonoクライアントのbaseURLでVercelプレビュー時のURLを修正しました。

【修正前】
```ts
return `https://${process.env.NEXT_PUBLIC_VERCEL_URL}`;
```

【修正後】
```ts
return `https://${process.env.VERCEL_URL}`;
```