### PR TITLE
Move client-side (window.location.origin) check to top

### DIFF
--- a/src/lib/getBaseUrl.ts
+++ b/src/lib/getBaseUrl.ts
@@ -1,16 +1,19 @@
 export function getBaseUrl() {
-  // Preview環境
+  //クライアント
+  if (typeof window !== "undefined") {
+    return window.location.origin;
+  }
+
+  //SEREVER｜Preview環境
   if (process.env.VERCEL_URL && process.env.VERCEL_ENV === "preview") {
     return `https://${process.env.VERCEL_URL}`;
   }
 
-  // Production本番
+  //SEREVER｜Production環境
   if (process.env.NODE_ENV === "production") {
     return process.env.NEXT_PUBLIC_ORIGIN!;
   }
 
   // ローカル開発
-  return typeof window !== "undefined"
-    ? window.location.origin
-    : process.env.NEXT_PUBLIC_ORIGIN!;
+  return process.env.NEXT_PUBLIC_ORIGIN!;
 }


### PR DESCRIPTION
## クライアントからのアクセス時のbaseURLを優先

## 概要
- getBaseUrl() 内でクライアント判定（window.location.origin）をトップに移動
- サーバー側は引き続きPreview / Production / Localを判定
- これにより、RCCのuseQuery / mutationでも正しい URLでHonoクライアントを使用可能
- CORS エラーやPreview環境での不整合を回避