### PR TITLE
Fix Timezone

### DIFF
--- a/src/app/dashboard/_components/MealRecordForm.tsx
+++ b/src/app/dashboard/_components/MealRecordForm.tsx
@@ -174,21 +174,32 @@ export const MealRecordForm = ({
 
   //Submit form
   const submitMealRecordSent = async (data: mealRecordInputSchemaOutput) => {
-    const sentDate =
-      mode === "edit" && editItem
-        ? {
-            ...data,
-            id: editItem.id,
-            userId: editItem.userId,
-            foodId: selectedFood?.id,
-          }
-        : { ...data, id: uuidv7(), userId: userId, foodId: selectedFood?.id };
+    const local = new Date(data.eatenAtLocal);
+    const utsIso = local.toISOString();
 
     if (mode === "edit" && editItem) {
+      const sentDate = {
+        ...data,
+        id: editItem.id,
+        userId: editItem.userId,
+        eatenAt: utsIso,
+        foodId: selectedFood?.id,
+      };
+
       if (editMutation.isPending) return;
+
       editMutation.mutate(sentDate);
+
       return;
     }
+
+    const sentDate = {
+      ...data,
+      id: uuidv7(),
+      userId: userId,
+      eatenAt: utsIso,
+      foodId: selectedFood?.id,
+    };
 
     if (addMutation.isPending) return;
     addMutation.mutate(sentDate);

--- a/src/app/dashboard/_components/_schema/MealRecordFormSchema.ts
+++ b/src/app/dashboard/_components/_schema/MealRecordFormSchema.ts
@@ -26,7 +26,7 @@ const mealRecordInputSchema = z
     foodName: data.foodName,
     gram: data.gram,
     kcal: data.kcal,
-    eatenAt: `${data.date} ${data.time}`,
+    eatenAtLocal: `${data.date}T${data.time}:00`,
   }));
 
 export const mealRecordSchemaResolver = zodResolver(mealRecordInputSchema);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -5,7 +5,7 @@ import {
 import { createServerRPC } from "@/lib/createServerRPC";
 import { getQueryClient, mealRecordkeys } from "@/lib/tanstack";
 import { getUserId } from "@/utils/db/auth";
-import { formatYYMMDD } from "@/utils/format/date";
+import { getTodayJST } from "@/utils/format/date";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 
 export const dynamic = "force-dynamic";
@@ -13,7 +13,8 @@ export const dynamic = "force-dynamic";
 export default async function Dashboard() {
   const userId = await getUserId();
   const queryClient = getQueryClient();
-  const date = formatYYMMDD(new Date());
+  //yyyy-MM-dd
+  const date = getTodayJST();
 
   await queryClient.prefetchQuery({
     queryKey: mealRecordkeys.dailyList(userId, date),

--- a/src/utils/format/date.ts
+++ b/src/utils/format/date.ts
@@ -41,3 +41,7 @@ export const formatUtcToJstTime = (utcDate: string) =>
 //UTC String to Tokyo String
 export const formatUtcToJstYYMMDD = (utcDate: string) =>
   formatInTimeZone(utcDate, JST, "yyyy-MM-dd", { locale: ja });
+
+export function getTodayJST() {
+  return formatInTimeZone(new Date(), JST, "yyyy-MM-dd");
+}


### PR DESCRIPTION
## Mealrecordのタイムゾーン修正

## 概要
プレビュー環境において、mealRecordのPOST / PUT時にタイムゾーンの不整合が発生しました。

原因は、ユーザーが入力した日時文字列（日本時間）をタイムゾーン情報を付与せずそのまま送信していたことにしたためです。
その結果、サーバー側では当該値を UTC として解釈し保存ししておりました。

さらに、取得時にUTC → JST変換を行っていたため、実際の入力値に対して+9時間のずれが発生していた。