### PR TITLE
Fix/create mealrecord by regularfood

### DIFF
--- a/src/app/dashboard/_components/RegularFoodLsits.tsx
+++ b/src/app/dashboard/_components/RegularFoodLsits.tsx
@@ -4,8 +4,8 @@ import { FetchErrorMessage } from "@/app/dashboard/_components/FetchErrorMessage
 import { ReguralrFoodListItem } from "@/app/dashboard/_components/ReguralrFoodListItem";
 import { List, Loading } from "@/components";
 import { Button } from "@/components/ui";
-import { SelectregularFood } from "@/db/schema";
 import { RegularFoodskeys, TErrCodes } from "@/lib/tanstack";
+import { fetchRegularFoods } from "@/services/regularFoods";
 import { useQuery } from "@tanstack/react-query";
 import { useRouter } from "next/navigation";
 
@@ -24,23 +24,13 @@ export const RegularFoodLsits = ({
 }: RegularFoodSelectorProps) => {
   const router = useRouter();
 
-  const { data, isLoading, isError, refetch } = useQuery<SelectregularFood[]>({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: RegularFoodskeys.list(userId),
-    queryFn: async () => {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_ORIGIN}/api/regular-foods?userId=${userId}`,
-        { cache: "no-store" },
-      );
-      if (!res.ok) {
-        throw new Error("RegularFoods fetch failed");
-      }
-      return res.json();
-    },
+    queryFn: async () => await fetchRegularFoods(),
     enabled: isRegularOpen,
     meta: { errCode: TErrCodes.REGULAR_FOOD_SEARCH_FAILED },
   });
 
-  if (isLoading) return <Loading />;
   if (isLoading) return <Loading />;
   if (isError) return <FetchErrorMessage onRetry={refetch} />;
 

--- a/src/app/dashboard/_components/ReguralrFoodListItem.tsx
+++ b/src/app/dashboard/_components/ReguralrFoodListItem.tsx
@@ -1,15 +1,17 @@
+"use client";
+
 import { List, Loading } from "@/components";
-import { SelectregularFood } from "@/db/schema";
 import { formatTime, formatUtcToJstYYMMDD } from "@/utils/format/date";
 import { historieskeys, mealRecordkeys } from "@/lib/tanstack";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { memo } from "react";
 import { toast } from "sonner";
 import { v7 as uuidv7 } from "uuid";
 import { addMealRecord } from "@/services/mealRecords";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { RegularFoodsResponse } from "@/shared/types";
 
 type ReguralrFoodItemProps = {
-  regularFood: SelectregularFood;
+  regularFood: RegularFoodsResponse;
   handleCloseAllWindows: () => void;
   date: string;
 };
@@ -45,9 +47,11 @@ const Component = ({
   });
 
   //Insert data to meralRecord
-  const handleAddMealRecords = (data: SelectregularFood) => {
+  const handleAddMealRecords = (data: RegularFoodsResponse) => {
     const time = formatTime(new Date());
-    const eatenAt = `${date} ${time}`;
+    const eatenAtLocal = `${date}T${time}:00`;
+    const local = new Date(eatenAtLocal);
+    const utsIso = local.toISOString();
 
     const sentDate = {
       id: uuidv7(),
@@ -55,7 +59,7 @@ const Component = ({
       foodName: data.foodName,
       gram: data.gram,
       kcal: data.kcal,
-      eatenAt: eatenAt,
+      eatenAt: utsIso,
     };
 
     if (addMutation.isPending) return;


### PR DESCRIPTION
## RegularFoodのタイムゾーン修正

概要

プレビュー環境において、regyularFoodからのPOST / PUT時にタイムゾーンの不整合が発生しました。

原因は、InputDate作成時の日時文字列（日本時間）をタイムゾーン情報を付与せずそのまま送信していたことにしたためです。
その結果、サーバー側では当該値を UTC として解釈し保存ししておりました。

さらに、取得時にUTC → JST変換を行っていたため、実際の入力値に対して+9時間のずれが発生していました。