### PR TITLE
Feat/hono rpc histories

### DIFF
--- a/src/app/dashboard/histories/page.tsx
+++ b/src/app/dashboard/histories/page.tsx
@@ -2,17 +2,34 @@ import {
   HistoryList,
   HistoryListSkeltone,
 } from "@/app/dashboard/histories/_components";
+import { getQueryClient, historieskeys } from "@/lib/tanstack";
+import { fetchHistroiesServer } from "@/services/histories";
 import { getUserId } from "@/utils/db/auth";
+import { getTodayJST } from "@/utils/format/date";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { Suspense } from "react";
 
 export default async function HistoryPage() {
   const userId = await getUserId();
+  const queryClient = getQueryClient();
+  const limit = "7";
+  //yyyy-MM-dd
+  const date = getTodayJST();
+
+  await queryClient.prefetchQuery({
+    queryKey: historieskeys.list(userId),
+    queryFn: async () => await fetchHistroiesServer(limit, date),
+  });
+
+  const dehydratedState = dehydrate(queryClient);
 
   return (
     <>
-      <Suspense fallback={<HistoryListSkeltone />}>
-        <HistoryList userId={userId} />
-      </Suspense>
+      <HydrationBoundary state={dehydratedState}>
+        <Suspense fallback={<HistoryListSkeltone />}>
+          <HistoryList userId={userId} limit={limit} date={date} />
+        </Suspense>
+      </HydrationBoundary>
     </>
   );
 }

--- a/src/backend/validators/index.ts
+++ b/src/backend/validators/index.ts
@@ -40,3 +40,12 @@ export const createTargetKcalPlansSchema = z.object({
 export const createProfileSchema = z.object({
   userName: z.string(),
 });
+
+// Histriesスキーマ
+export const historiesQuerySchema = z.object({
+  limit: z
+    .string()
+    .transform((val) => Number(val))
+    .refine((num) => !isNaN(num) && num > 0 && num <= 10),
+  currentCursor: z.string(),
+});

--- a/src/services/histories.ts
+++ b/src/services/histories.ts
@@ -1,0 +1,29 @@
+import { createClientRPC } from "@/lib/createClientRPC";
+import { createServerRPC } from "@/lib/createServerRPC";
+
+export const fetchHistroiesClient = async (
+  limit: string,
+  currentCursor: string,
+) => {
+  const client = await createClientRPC();
+
+  const res = await client.api.dashboard.histories.$get({
+    query: { limit, currentCursor },
+  });
+
+  const data = await res.json();
+  return data;
+};
+
+export const fetchHistroiesServer = async (
+  limit: string,
+  currentCursor: string,
+) => {
+  const client = await createServerRPC();
+  const res = await client.api.dashboard.histories.$get({
+    query: { limit, currentCursor },
+  });
+
+  const data = await res.json();
+  return data;
+};

--- a/src/shared/types/index.ts
+++ b/src/shared/types/index.ts
@@ -55,3 +55,16 @@ export type CreateProfileInput = Omit<
   InsertProfileRecord,
   "id" | "createdAt" | "updatedAt" | "deletedAt"
 >;
+
+//Histories
+export type HistoryItem = {
+  date: string;
+  totalKcal: number;
+  targetKcal: number;
+};
+
+export type HistoriesResponse = {
+  historiesRecord: HistoryItem[];
+  nextCursor: string;
+  hasNext: boolean;
+};


### PR DESCRIPTION
## フロントをHono API(RPC)に置き換え【 historiesページ 】

#122

## 概要

- Hono用の型作成
- 各APIクライアントをHonoRPCへ置き換え
- フロントの関数を置き換え
- page.tsxにprefetchの追加
- Honoバリデーションの追加