### PR TITLE
Feat/hono rpc histories child

### DIFF
--- a/src/app/dashboard/_components/MealRecordLists.tsx
+++ b/src/app/dashboard/_components/MealRecordLists.tsx
@@ -2,7 +2,7 @@
 
 import { FetchErrorMessage, MealRecordItem } from "@/app/dashboard/_components";
 import { mealRecordkeys, TErrCodes } from "@/lib/tanstack";
-import { fetchMealRecords } from "@/services/mealRecords";
+import { fetchMealRecordsClient } from "@/services/mealRecords";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { memo } from "react";
 
@@ -14,7 +14,7 @@ type MealRecordListsProps = {
 const Component = ({ userId, date }: MealRecordListsProps) => {
   const { data, isError, refetch } = useSuspenseQuery({
     queryKey: mealRecordkeys.dailyList(userId, date),
-    queryFn: async () => await fetchMealRecords(date),
+    queryFn: async () => await fetchMealRecordsClient(date),
     meta: { errCode: TErrCodes.MEAL_FETCH_FAILED },
   });
 

--- a/src/app/dashboard/histories/[date]/page.tsx
+++ b/src/app/dashboard/histories/[date]/page.tsx
@@ -7,6 +7,7 @@ import { formatDateWithDay } from "@/utils/format/date";
 import { getQueryClient, mealRecordkeys } from "@/lib/tanstack";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
 import { getUserId } from "@/utils/db/auth";
+import { fetchMealRecordsServer } from "@/services/mealRecords";
 
 export default async function MealDetailPage({
   params,
@@ -19,13 +20,7 @@ export default async function MealDetailPage({
 
   await queryClient.prefetchQuery({
     queryKey: mealRecordkeys.dailyList(userId, targetDate),
-    queryFn: async () => {
-      const res = await fetch(
-        `${process.env.NEXT_PUBLIC_ORIGIN}/api/meal-records?userId=${userId}&date=${targetDate}`,
-      );
-      if (!res.ok) throw new Error("fetch failed");
-      return res.json();
-    },
+    queryFn: async () => await fetchMealRecordsServer(targetDate),
   });
 
   const dehydratedState = dehydrate(queryClient);

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -2,8 +2,8 @@ import {
   MealRecordSection,
   ProgressSection,
 } from "@/app/dashboard/_components";
-import { createServerRPC } from "@/lib/createServerRPC";
 import { getQueryClient, mealRecordkeys } from "@/lib/tanstack";
+import { fetchMealRecordsServer } from "@/services/mealRecords";
 import { getUserId } from "@/utils/db/auth";
 import { getTodayJST } from "@/utils/format/date";
 import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
@@ -18,16 +18,7 @@ export default async function Dashboard() {
 
   await queryClient.prefetchQuery({
     queryKey: mealRecordkeys.dailyList(userId, date),
-    queryFn: async () => {
-      const client = await createServerRPC();
-
-      const res = await client.api.dashboard.mealrecords.$get({
-        query: { date },
-      });
-
-      const data = await res.json();
-      return data.mealRecords;
-    },
+    queryFn: async () => fetchMealRecordsServer(date),
   });
 
   const dehydratedState = dehydrate(queryClient);

--- a/src/services/mealRecords.ts
+++ b/src/services/mealRecords.ts
@@ -1,9 +1,19 @@
 import { createClientRPC } from "@/lib/createClientRPC";
+import { createServerRPC } from "@/lib/createServerRPC";
 import { MealRecordRequest } from "@/shared/types/";
 
 //fetch
-export const fetchMealRecords = async (date: string) => {
+export const fetchMealRecordsClient = async (date: string) => {
   const client = await createClientRPC();
+  const res = await client.api.dashboard.mealrecords.$get({
+    query: { date },
+  });
+  const data = await res.json();
+  return data.mealRecords;
+};
+
+export const fetchMealRecordsServer = async (date: string) => {
+  const client = await createServerRPC();
   const res = await client.api.dashboard.mealrecords.$get({
     query: { date },
   });


### PR DESCRIPTION
## フロントをHono API(RPC)に置き換え【 Histories/ 子ページ 】

#122 

## 概要

- サーバー用fetch API Client作成
- フロントの関数を置き換え
- クライアント用fetch API Clientの関数名変更
- mealrecordトップページの関数名をクライアント用に変更