### PR TITLE
Add invalidateQueries

### DIFF
--- a/src/app/dashboard/target-kcal-plans/_component/TargetKcalActionMenu.tsx
+++ b/src/app/dashboard/target-kcal-plans/_component/TargetKcalActionMenu.tsx
@@ -35,6 +35,10 @@ const Component = ({
       queryClient.invalidateQueries({
         queryKey: TargetKcalkeys.list(sentData.userId),
       });
+
+      queryClient.invalidateQueries({
+        queryKey: TargetKcalkeys.effective(sentData.userId),
+      });
     },
     onError: () => {
       console.log("Error delete targetKcal");


### PR DESCRIPTION
## 目標Kcal削除時のキャッシュ更新の修正

## 概要
ユーザーが目標Kcalリストから削除した際のダッシュボードの、当日の目標カロリーを更新するよう修正

- Dlete mutaionの成功時にinvalidateQueriesに該当データのquerykeyを設置