### PR TITLE
Add queryKeys

### DIFF
--- a/src/app/dashboard/target-kcal-plans/_component/TargetKcalActionMenu.tsx
+++ b/src/app/dashboard/target-kcal-plans/_component/TargetKcalActionMenu.tsx
@@ -2,7 +2,7 @@ import { TargetKcalPlanForm } from "@/app/dashboard/target-kcal-plans/_component
 import { Loading } from "@/components";
 import { Button } from "@/components/ui";
 import { useModalControl } from "@/hooks";
-import { TargetKcalkeys } from "@/lib/tanstack";
+import { historieskeys, TargetKcalkeys } from "@/lib/tanstack";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { EllipsisVertical, Pencil, Trash2, X } from "lucide-react";
 import { memo } from "react";
@@ -38,6 +38,10 @@ const Component = ({
 
       queryClient.invalidateQueries({
         queryKey: TargetKcalkeys.effective(sentData.userId),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: historieskeys.list(sentData.userId),
       });
     },
     onError: () => {

--- a/src/app/dashboard/target-kcal-plans/_component/TargetKcalPlanForm.tsx
+++ b/src/app/dashboard/target-kcal-plans/_component/TargetKcalPlanForm.tsx
@@ -21,7 +21,7 @@ import {
   FieldLabel,
 } from "@/components/ui/field";
 import { formattedTomorrow, formatYYMMDD } from "@/utils/format/date";
-import { TargetKcalkeys } from "@/lib/tanstack";
+import { historieskeys, TargetKcalkeys } from "@/lib/tanstack";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import { Controller, useForm } from "react-hook-form";
@@ -93,6 +93,10 @@ export const TargetKcalPlanForm = ({
       queryClient.invalidateQueries({
         queryKey: TargetKcalkeys.effective(userId),
       });
+
+      queryClient.invalidateQueries({
+        queryKey: historieskeys.list(userId),
+      });
       handleFormWindow();
     },
     onError: () => {
@@ -110,6 +114,10 @@ export const TargetKcalPlanForm = ({
 
       queryClient.invalidateQueries({
         queryKey: TargetKcalkeys.effective(userId),
+      });
+
+      queryClient.invalidateQueries({
+        queryKey: historieskeys.list(userId),
       });
       handleCloseAllWindows?.();
     },


### PR DESCRIPTION
## 目標Kcal編集・削除・追加時に履歴ページを更新するよう修正

## 概要
ユーザーが目標Kcalの操作を行った際、履歴ページで使用している1日の目標カロリーのUIが更新されない件を修正しました。

- 各mutation後にinvaldateQueryでqueryKeyを更新